### PR TITLE
Add Deep Research search/fetch tools and update tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
 ## Features
 
 - **Multi-Source Support**: Search and download papers from arXiv, PubMed, bioRxiv, medRxiv, Google Scholar, IACR ePrint Archive, Semantic Scholar.
+- **Deep Research Ready**: Provides the standardized `search` and `fetch` tools required by OpenAI Deep Research and ChatGPT connectors.
 - **Standardized Output**: Papers are returned in a consistent dictionary format via the `Paper` class.
 - **Asynchronous Tools**: Efficiently handles network requests using `httpx`.
 - **MCP Integration**: Compatible with MCP clients for LLM context enhancement.


### PR DESCRIPTION
## Summary
- add an aggregate Deep Research `search` tool that normalizes output and caches metadata
- implement a `fetch` tool that returns full document payloads with cached metadata fallbacks
- refactor tests to cover the new Deep Research flow with stubbed searchers and update documentation

## Testing
- pytest tests/test_server.py

------
https://chatgpt.com/codex/tasks/task_e_68cbcd09ccc8832f9420c7393a5cbaf9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified, concurrent multi-source paper search with de-duplication and configurable result limits.
  - Added sources: CrossRef and Semantic Scholar.
  - Consistent fetch endpoint returning full text and rich metadata.
  - Caching improves repeated fetch performance.

- Refactor
  - Streamlined search architecture for reliability and observability; preserves existing per-source tools.

- Documentation
  - Added “Deep Research Ready” to Features, outlining standardized search/fetch capabilities.

- Tests
  - Rewrote suite to validate asynchronous aggregated search and fetch behavior using synthetic data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->