### PR TITLE
Support streamable HTTP transport for Smithery deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ COPY . .
 RUN pip install --upgrade pip \
     && pip install --no-cache-dir .
 
-# Expose port if necessary (MCP servers use stdio; no port to expose)
+# Expose the HTTP port used by the MCP server
+EXPOSE 8081
 
 # Command to run the MCP server
 CMD ["python", "-m", "paper_search_mcp.server"]

--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -188,14 +188,11 @@ def _format_search_result(source: str, paper: Dict[str, Any]) -> Dict[str, Any]:
     document_id = _build_document_id(source, paper)
     metadata = _prepare_metadata(source, paper)
     _update_cache(document_id, metadata)
-    snippet = (metadata["abstract"] or "")[:300]
-    url = metadata["url"] or metadata["pdf_url"] or ""
+    url = metadata.get("url") or metadata.get("pdf_url") or ""
     return {
         "id": document_id,
         "title": metadata["title"],
         "url": url,
-        "snippet": snippet,
-        "source": source,
     }
 
 

--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -283,19 +283,24 @@ async def search(query: str, max_results: int = DEFAULT_MAX_RESULTS) -> CallTool
 
 
 @mcp.tool("fetch")
-async def fetch(document_id: str) -> CallToolResult:
+async def fetch(id: str | None = None, document_id: str | None = None) -> CallToolResult:
     """Fetch full document content for a search result."""
 
-    if not document_id:
+    identifier = document_id or id
+
+    if not identifier:
         raise ValueError("Document identifier is required")
 
-    metadata = SEARCH_CACHE.get(document_id)
+    if document_id and id and document_id != id:
+        raise ValueError("Conflicting identifiers provided")
+
+    metadata = SEARCH_CACHE.get(identifier)
     if metadata is None:
-        source, _, paper_id = document_id.partition(":")
+        source, _, paper_id = identifier.partition(":")
         metadata = {
             "source": source,
             "paper_id": paper_id,
-            "title": paper_id or document_id,
+            "title": paper_id or identifier,
             "abstract": "",
             "doi": "",
             "url": "",
@@ -318,7 +323,7 @@ async def fetch(document_id: str) -> CallToolResult:
     if not full_text:
         full_text = metadata.get("abstract", "") or "Content unavailable."
 
-    return _build_fetch_response(document_id, metadata, full_text)
+    return _build_fetch_response(identifier, metadata, full_text)
 
 
 # Tool definitions

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,13 +1,11 @@
-# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
-
+runtime: "container"
+build:
+  dockerfile: "Dockerfile"
+  dockerBuildPath: "."
 startCommand:
-  type: stdio
+  type: "http"
+  path: "/mcp"
   configSchema:
-    # JSON Schema defining the configuration options for the MCP.
-    type: object
+    type: "object"
     properties: {}
-  commandFunction:
-    # A JS function that produces the CLI command based on the given config to start the MCP on stdio.
-    |-
-    (config) => ({ command: 'python', args: ['-m', 'paper_search_mcp.server'] })
   exampleConfig: {}


### PR DESCRIPTION
## Summary
- add environment-aware transport detection so the MCP server can run over Streamable HTTP when a PORT is provided
- expose the HTTP port in the Dockerfile and switch the smithery configuration to the container runtime

## Testing
- .venv/bin/python -m pytest *(fails: bioRxiv download/search rely on live service responses and Semantic Scholar search signature mismatch in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68cbd41dfe48832fa229a2d649e80f92

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Server supports environment-driven transport selection (stdio, SSE, or HTTP) with sensible host/port defaults.
  - Search/fetch now returns richer metadata (authors, dates, pdf_url, keywords, references) and improved URL handling.

- Refactor
  - Centralized startup flow with a clear entry point and improved startup logging.

- Chores
  - Container now exposes port 8081 and runtime config updated to run in a container and start over HTTP at /mcp.
  - Simplified configuration schema and removed legacy command-generation logic.
  - Introduced configurable cache limit (MAX_CACHE_SIZE).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->