### PR TITLE
Add Sci-Hub MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
 
 - [Overview](#overview)
 - [Features](#features)
+- [Sci-Hub](#sci-hub)
 - [Installation](#installation)
   - [Quick Start](#quick-start)
     - [Install Package](#install-package)
@@ -33,7 +34,7 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
 
 ## Features
 
-- **Multi-Source Support**: Search and download papers from arXiv, PubMed, bioRxiv, medRxiv, Google Scholar, IACR ePrint Archive, Semantic Scholar.
+- **Multi-Source Support**: Search and download papers from arXiv, PubMed, bioRxiv, medRxiv, Google Scholar, IACR ePrint Archive, Semantic Scholar, and Sci-Hub (optional).
 - **Deep Research Ready**: Provides the standardized `search` and `fetch` tools required by OpenAI Deep Research and ChatGPT connectors.
 - **Standardized Output**: Papers are returned in a consistent dictionary format via the `Paper` class.
 - **Asynchronous Tools**: Efficiently handles network requests using `httpx`.
@@ -79,7 +80,8 @@ For users who want to quickly run the server:
            "paper_search_mcp.server"
          ],
          "env": {
-           "SEMANTIC_SCHOLAR_API_KEY": "" // Optional: For enhanced Semantic Scholar features
+           "SEMANTIC_SCHOLAR_API_KEY": "", // Optional: For enhanced Semantic Scholar features
+           "PAPER_SEARCH_MCP_DISABLE_SCIHUB": "false" // Optional: Set to "true" to hide Sci-Hub tools
          }
        }
      }

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ A Model Context Protocol (MCP) server for searching and downloading academic pap
 
 - [Overview](#overview)
 - [Features](#features)
-- [Sci-Hub](#sci-hub)
 - [Installation](#installation)
   - [Quick Start](#quick-start)
     - [Install Package](#install-package)

--- a/paper_search_mcp/academic_platforms/sci_hub.py
+++ b/paper_search_mcp/academic_platforms/sci_hub.py
@@ -15,9 +15,18 @@ from bs4 import BeautifulSoup
 class SciHubFetcher:
     """Simple Sci-Hub PDF downloader."""
 
-    def __init__(self, base_url: str = "https://sci-hub.se", output_dir: str = "./downloads"):
+    MIRRORS = (
+        "https://sci-hub.ru",
+        "https://sci-hub.st",
+        "https://sci-hub.su",
+        "https://sci-hub.box",
+        "https://sci-hub.red",
+    )
+
+    def __init__(self, base_url: str = "https://sci-hub.ru", output_dir: str = "./downloads"):
         """Initialize with Sci-Hub URL and output directory."""
         self.base_url = base_url.rstrip("/")
+        self.mirrors = [self.base_url] + [m for m in self.MIRRORS if m != self.base_url]
         self.output_dir = Path(output_dir)
         self.output_dir.mkdir(parents=True, exist_ok=True)
         self.session = requests.Session()
@@ -81,76 +90,68 @@ class SciHubFetcher:
             if identifier.endswith('.pdf'):
                 return identifier
 
-            # Search on Sci-Hub
-            search_url = f"{self.base_url}/{identifier}"
-            response = self.session.get(search_url, verify=False, timeout=20)
-            
-            if response.status_code != 200:
-                return None
+            for base_url in self.mirrors:
+                try:
+                    # Search on Sci-Hub
+                    search_url = f"{base_url}/{identifier}"
+                    response = self.session.get(search_url, verify=False, timeout=20)
+                    if response.status_code != 200:
+                        continue
 
-            soup = BeautifulSoup(response.content, 'html.parser')
-            
-            # Check for article not found
-            if "article not found" in response.text.lower():
-                logging.warning("Article not found on Sci-Hub")
-                return None
+                    soup = BeautifulSoup(response.content, 'html.parser')
 
-            # Look for embed tag with PDF (most common in modern Sci-Hub)
-            embed = soup.find('embed', {'type': 'application/pdf'})
-            logging.debug(f"Found embed tag: {embed}")
-            if embed:
-                src = embed.get('src') if hasattr(embed, 'get') else None
-                logging.debug(f"Embed src: {src}")
-                if src and isinstance(src, str):
-                    if src.startswith('//'):
-                        pdf_url = 'https:' + src
-                        logging.debug(f"Returning PDF URL: {pdf_url}")
-                        return pdf_url
-                    elif src.startswith('/'):
-                        pdf_url = self.base_url + src
-                        logging.debug(f"Returning PDF URL: {pdf_url}")
-                        return pdf_url
-                    else:
-                        logging.debug(f"Returning PDF URL: {src}")
-                        return src
+                    # Check for article not found
+                    if "article not found" in response.text.lower():
+                        continue
 
-            # Look for iframe with PDF (fallback)
-            iframe = soup.find('iframe')
-            if iframe:
-                src = iframe.get('src') if hasattr(iframe, 'get') else None
-                if src and isinstance(src, str):
-                    if src.startswith('//'):
-                        return 'https:' + src
-                    elif src.startswith('/'):
-                        return self.base_url + src
-                    else:
-                        return src
+                    # Look for embed tag with PDF (most common in modern Sci-Hub)
+                    embed = soup.find('embed', {'type': 'application/pdf'})
+                    if embed:
+                        src = embed.get('src') if hasattr(embed, 'get') else None
+                        if src and isinstance(src, str):
+                            if src.startswith('//'):
+                                return 'https:' + src
+                            if src.startswith('/'):
+                                return base_url + src
+                            return src
 
-            # Look for download button with onclick
-            for button in soup.find_all('button'):
-                onclick = button.get('onclick', '') if hasattr(button, 'get') else ''
-                if isinstance(onclick, str) and 'pdf' in onclick.lower():
-                    # Extract URL from onclick JavaScript
-                    url_match = re.search(r"location\.href='([^']+)'", onclick)
-                    if url_match:
-                        url = url_match.group(1)
-                        if url.startswith('//'):
-                            return 'https:' + url
-                        elif url.startswith('/'):
-                            return self.base_url + url
-                        else:
-                            return url
+                    # Look for iframe with PDF (fallback)
+                    iframe = soup.find('iframe')
+                    if iframe:
+                        src = iframe.get('src') if hasattr(iframe, 'get') else None
+                        if src and isinstance(src, str):
+                            if src.startswith('//'):
+                                return 'https:' + src
+                            if src.startswith('/'):
+                                return base_url + src
+                            return src
 
-            # Look for direct download links
-            for link in soup.find_all('a'):
-                href = link.get('href', '') if hasattr(link, 'get') else ''
-                if isinstance(href, str) and href and ('pdf' in href.lower() or href.endswith('.pdf')):
-                    if href.startswith('//'):
-                        return 'https:' + href
-                    elif href.startswith('/'):
-                        return self.base_url + href
-                    elif href.startswith('http'):
-                        return href
+                    # Look for download button with onclick
+                    for button in soup.find_all('button'):
+                        onclick = button.get('onclick', '') if hasattr(button, 'get') else ''
+                        if isinstance(onclick, str) and 'pdf' in onclick.lower():
+                            # Extract URL from onclick JavaScript
+                            url_match = re.search(r"location\.href='([^']+)'", onclick)
+                            if url_match:
+                                url = url_match.group(1)
+                                if url.startswith('//'):
+                                    return 'https:' + url
+                                if url.startswith('/'):
+                                    return base_url + url
+                                return url
+
+                    # Look for direct download links
+                    for link in soup.find_all('a'):
+                        href = link.get('href', '') if hasattr(link, 'get') else ''
+                        if isinstance(href, str) and href and ('pdf' in href.lower() or href.endswith('.pdf')):
+                            if href.startswith('//'):
+                                return 'https:' + href
+                            if href.startswith('/'):
+                                return base_url + href
+                            if href.startswith('http'):
+                                return href
+                except Exception as mirror_error:
+                    logging.warning("Sci-Hub mirror %s failed: %s", base_url, mirror_error)
 
             return None
 

--- a/paper_search_mcp/academic_platforms/sci_hub.py
+++ b/paper_search_mcp/academic_platforms/sci_hub.py
@@ -10,6 +10,7 @@ from typing import Optional
 
 import requests
 from bs4 import BeautifulSoup
+from requests.exceptions import SSLError
 
 
 class SciHubFetcher:
@@ -60,7 +61,7 @@ class SciHubFetcher:
                 return None
 
             # Download the PDF
-            response = self.session.get(pdf_url, verify=False, timeout=30)
+            response = self._request_with_ssl_fallback(pdf_url, timeout=30)
             
             if response.status_code != 200:
                 logging.error(f"Failed to download PDF, status {response.status_code}")
@@ -83,6 +84,18 @@ class SciHubFetcher:
             logging.error(f"Error downloading PDF for {identifier}: {e}")
             return None
 
+    def _request_with_ssl_fallback(self, url: str, timeout: int) -> requests.Response:
+        """Attempt a verified HTTPS request, then fall back when cert validation fails."""
+        try:
+            return self.session.get(url, timeout=timeout)
+        except SSLError as ssl_error:
+            logging.warning(
+                "SSL certificate validation failed for %s; retrying with verification disabled: %s",
+                url,
+                ssl_error,
+            )
+            return self.session.get(url, verify=False, timeout=timeout)
+
     def _get_direct_url(self, identifier: str) -> Optional[str]:
         """Get the direct PDF URL from Sci-Hub."""
         try:
@@ -94,7 +107,7 @@ class SciHubFetcher:
                 try:
                     # Search on Sci-Hub
                     search_url = f"{base_url}/{identifier}"
-                    response = self.session.get(search_url, verify=False, timeout=20)
+                    response = self._request_with_ssl_fallback(search_url, timeout=20)
                     if response.status_code != 200:
                         continue
 

--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -12,6 +12,7 @@ from typing import Any, Dict, List, Optional
 import httpx
 from mcp.server.fastmcp import FastMCP
 from mcp.types import CallToolResult, TextContent
+from PyPDF2 import PdfReader
 
 from .academic_platforms.arxiv import ArxivSearcher
 from .academic_platforms.pubmed import PubMedSearcher
@@ -22,10 +23,23 @@ from .academic_platforms.iacr import IACRSearcher
 from .academic_platforms.semantic import SemanticSearcher
 from .academic_platforms.crossref import CrossRefSearcher
 
-# from .academic_platforms.hub import SciHubSearcher
+from .academic_platforms.sci_hub import SciHubFetcher
 from .paper import Paper
 
 logger = logging.getLogger(__name__)
+
+
+def _env_flag(name: str, default: bool) -> bool:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    logger.warning("Invalid boolean value for %s=%r; using default=%s", name, raw, default)
+    return default
 
 
 def _normalize_transport(value: str | None) -> str | None:
@@ -87,6 +101,7 @@ mcp = FastMCP(
 )
 
 DOWNLOAD_DIR = os.environ.get("PAPER_SEARCH_DOWNLOAD_DIR", "./downloads")
+DISABLE_SCIHUB = _env_flag("PAPER_SEARCH_MCP_DISABLE_SCIHUB", False)
 DEFAULT_MAX_RESULTS = 15
 RESULTS_PER_SOURCE = 5
 MAX_CACHE_SIZE = 128
@@ -112,7 +127,7 @@ google_scholar_searcher = SEARCHERS["google_scholar"]
 iacr_searcher = SEARCHERS["iacr"]
 semantic_searcher = SEARCHERS["semantic"]
 crossref_searcher = SEARCHERS["crossref"]
-# scihub_searcher = SciHubSearcher()
+scihub_searcher = None if DISABLE_SCIHUB else SciHubFetcher()
 
 
 # Cached metadata for fetch requests
@@ -479,6 +494,91 @@ async def download_iacr(paper_id: str, save_path: str = "./downloads") -> str:
         Path to the downloaded PDF file.
     """
     return iacr_searcher.download_pdf(paper_id, save_path)
+
+
+if not DISABLE_SCIHUB:
+    @mcp.tool()
+    async def download_scihub(identifier: str, save_path: str = "./downloads") -> str:
+        """Download a PDF via Sci-Hub using DOI, PMID, URL, or direct PDF URL.
+
+        Args:
+            identifier: DOI, PMID, article URL, or direct PDF URL.
+            save_path: Directory to save the PDF (default: './downloads').
+        Returns:
+            Path to the downloaded PDF file, or an error message on failure.
+        """
+        try:
+            fetcher = SciHubFetcher(output_dir=save_path)
+            result = fetcher.download_pdf(identifier)
+            return result if result else "Failed to download PDF from Sci-Hub."
+        except Exception as e:
+            return f"Failed to download PDF from Sci-Hub: {e}"
+
+
+    @mcp.tool()
+    async def search_scihub(identifier: str, max_results: int = 1) -> List[Dict]:
+        """Resolve a Sci-Hub identifier into a downloadable PDF result.
+
+        Args:
+            identifier: DOI, PMID, article URL, or direct PDF URL.
+            max_results: Maximum number of results to return (default: 1).
+        Returns:
+            List containing a single resolved result if found, otherwise empty list.
+        """
+        if not identifier or not identifier.strip() or max_results < 1:
+            return []
+
+        try:
+            fetcher = SciHubFetcher(output_dir=DOWNLOAD_DIR)
+            pdf_url = fetcher._get_direct_url(identifier.strip())
+            if not pdf_url:
+                return []
+            return [{
+                "paper_id": identifier.strip(),
+                "title": f"Sci-Hub result for {identifier.strip()}",
+                "authors": "",
+                "abstract": "",
+                "doi": "",
+                "published_date": "",
+                "pdf_url": pdf_url,
+                "url": pdf_url,
+                "source": "scihub",
+                "updated_date": "",
+                "categories": "",
+                "keywords": "",
+                "citations": 0,
+                "references": "",
+                "extra": "",
+            }]
+        except Exception:
+            return []
+
+
+    @mcp.tool()
+    async def read_scihub_paper(identifier: str, save_path: str = "./downloads") -> str:
+        """Download and extract text from a paper via Sci-Hub.
+
+        Args:
+            identifier: DOI, PMID, article URL, or direct PDF URL.
+            save_path: Directory where the PDF is/will be saved (default: './downloads').
+        Returns:
+            Extracted paper text, or an error message if unavailable.
+        """
+        try:
+            fetcher = SciHubFetcher(output_dir=save_path)
+            pdf_path = fetcher.download_pdf(identifier)
+            if not pdf_path:
+                return "Failed to download PDF from Sci-Hub."
+
+            reader = PdfReader(pdf_path)
+            text_parts: List[str] = []
+            for page in reader.pages:
+                page_text = page.extract_text() or ""
+                text_parts.append(page_text)
+            text = "\n".join(text_parts).strip()
+            return text or "No extractable text found in PDF."
+        except Exception as e:
+            return f"Failed to read paper from Sci-Hub: {e}"
 
 
 @mcp.tool()

--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -151,6 +151,29 @@ def _split_semicolon_values(value: str | None) -> List[str]:
     return [item.strip() for item in value.split(";") if item.strip()]
 
 
+def _build_arxiv_pdf_url(paper_id: str) -> str:
+    return f"https://arxiv.org/pdf/{paper_id}.pdf"
+
+
+def _build_biorxiv_pdf_url(paper_id: str) -> str:
+    return f"https://www.biorxiv.org/content/{paper_id}v1.full.pdf"
+
+
+def _build_medrxiv_pdf_url(paper_id: str) -> str:
+    return f"https://www.medrxiv.org/content/{paper_id}v1.full.pdf"
+
+
+def _build_iacr_pdf_url(paper_id: str) -> str:
+    return f"https://eprint.iacr.org/{paper_id}.pdf"
+
+
+def _resolve_download_result(server_path: str, download_url: str) -> str:
+    # Non-stdio transports cannot return a meaningful local server file path to clients.
+    if SELECTED_TRANSPORT != "stdio":
+        return download_url
+    return server_path
+
+
 def _build_document_id(source: str, paper: Dict[str, Any]) -> str:
     candidate_keys = [
         paper.get("paper_id"),
@@ -437,8 +460,12 @@ async def download_arxiv(paper_id: str, save_path: str = "./downloads") -> str:
     Returns:
         Path to the downloaded PDF file.
     """
+    pdf_url = _build_arxiv_pdf_url(paper_id)
+    if SELECTED_TRANSPORT != "stdio":
+        return pdf_url
     async with httpx.AsyncClient() as client:
-        return arxiv_searcher.download_pdf(paper_id, save_path)
+        server_path = arxiv_searcher.download_pdf(paper_id, save_path)
+    return _resolve_download_result(server_path, pdf_url)
 
 
 @mcp.tool()
@@ -467,7 +494,11 @@ async def download_biorxiv(paper_id: str, save_path: str = "./downloads") -> str
     Returns:
         Path to the downloaded PDF file.
     """
-    return biorxiv_searcher.download_pdf(paper_id, save_path)
+    pdf_url = _build_biorxiv_pdf_url(paper_id)
+    if SELECTED_TRANSPORT != "stdio":
+        return pdf_url
+    server_path = biorxiv_searcher.download_pdf(paper_id, save_path)
+    return _resolve_download_result(server_path, pdf_url)
 
 
 @mcp.tool()
@@ -480,7 +511,11 @@ async def download_medrxiv(paper_id: str, save_path: str = "./downloads") -> str
     Returns:
         Path to the downloaded PDF file.
     """
-    return medrxiv_searcher.download_pdf(paper_id, save_path)
+    pdf_url = _build_medrxiv_pdf_url(paper_id)
+    if SELECTED_TRANSPORT != "stdio":
+        return pdf_url
+    server_path = medrxiv_searcher.download_pdf(paper_id, save_path)
+    return _resolve_download_result(server_path, pdf_url)
 
 
 @mcp.tool()
@@ -493,7 +528,11 @@ async def download_iacr(paper_id: str, save_path: str = "./downloads") -> str:
     Returns:
         Path to the downloaded PDF file.
     """
-    return iacr_searcher.download_pdf(paper_id, save_path)
+    pdf_url = _build_iacr_pdf_url(paper_id)
+    if SELECTED_TRANSPORT != "stdio":
+        return pdf_url
+    server_path = iacr_searcher.download_pdf(paper_id, save_path)
+    return _resolve_download_result(server_path, pdf_url)
 
 
 if not DISABLE_SCIHUB:
@@ -509,6 +548,9 @@ if not DISABLE_SCIHUB:
         """
         try:
             fetcher = SciHubFetcher(output_dir=save_path)
+            if SELECTED_TRANSPORT != "stdio":
+                pdf_url = fetcher._get_direct_url(identifier)
+                return pdf_url or "Failed to resolve PDF URL from Sci-Hub."
             result = fetcher.download_pdf(identifier)
             return result if result else "Failed to download PDF from Sci-Hub."
         except Exception as e:
@@ -716,7 +758,13 @@ async def download_semantic(paper_id: str, save_path: str = "./downloads") -> st
     Returns:
         Path to the downloaded PDF file.
     """ 
-    return semantic_searcher.download_pdf(paper_id, save_path)
+    paper = semantic_searcher.get_paper_details(paper_id)
+    if not paper or not paper.pdf_url:
+        return f"Error: Could not find PDF URL for paper {paper_id}"
+    if SELECTED_TRANSPORT != "stdio":
+        return paper.pdf_url
+    server_path = semantic_searcher.download_pdf(paper_id, save_path)
+    return _resolve_download_result(server_path, paper.pdf_url)
 
 
 @mcp.tool()

--- a/paper_search_mcp/server.py
+++ b/paper_search_mcp/server.py
@@ -512,6 +512,12 @@ if not DISABLE_SCIHUB:
             result = fetcher.download_pdf(identifier)
             return result if result else "Failed to download PDF from Sci-Hub."
         except Exception as e:
+            logger.warning(
+                "download_scihub failed for identifier=%s save_path=%s: %s",
+                identifier,
+                save_path,
+                e,
+            )
             return f"Failed to download PDF from Sci-Hub: {e}"
 
 
@@ -550,7 +556,13 @@ if not DISABLE_SCIHUB:
                 "references": "",
                 "extra": "",
             }]
-        except Exception:
+        except Exception as e:
+            logger.warning(
+                "search_scihub failed for identifier=%s max_results=%s: %s",
+                identifier,
+                max_results,
+                e,
+            )
             return []
 
 
@@ -578,6 +590,12 @@ if not DISABLE_SCIHUB:
             text = "\n".join(text_parts).strip()
             return text or "No extractable text found in PDF."
         except Exception as e:
+            logger.warning(
+                "read_scihub_paper failed for identifier=%s save_path=%s: %s",
+                identifier,
+                save_path,
+                e,
+            )
             return f"Failed to read paper from Sci-Hub: {e}"
 
 


### PR DESCRIPTION
There were no MCP tools connected to the Sci-Hub fetcher

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional Sci-Hub source with automatic mirror fallback for more reliable paper retrieval
  * Tools to search Sci-Hub by identifier, download papers, and extract text from PDFs
* **Chores**
  * Sci-Hub integration can be toggled via a new Quick Start environment variable (defaults to false)
  * Quick Start example updated and minor formatting tweaks in config comments
<!-- end of auto-generated comment: release notes by coderabbit.ai -->